### PR TITLE
Adds a code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at rob@prouse.org. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains documents related to the overall governance of the NUnit organization as well as the individual projects under NUnit. It is currently under development.
 
+## Code of Conduct
+
+Please note that all NUnit projecst are released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in these projects you agree to abide by its terms.
+
 ## Structure of this Repository
 
 The root directory contains approved and published documents describing overall governance of the nunit organization. Subdirectories are used for governance documentation specific to individual projects.
@@ -10,4 +14,8 @@ Draft documents at all levels are included in the `drafts` folder. We use this a
 
 ## Documents
 
-_None Yet - Still Under Construction_
+- [NUnit Project Governance](governance.md)
+- [NUnit Community Decision Making Process](decisions.md)
+- [NUnit Software Projects](projects.md)
+- [NUnit Vision Statement](vision.md)
+- [Contributor Code of Conduct](CODE_OF_CONDUCT.md)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains documents related to the overall governance of the NUni
 
 ## Code of Conduct
 
-Please note that all NUnit projecst are released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in these projects you agree to abide by its terms.
+Please note that all NUnit projects are released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in these projects you agree to abide by its terms.
 
 ## Structure of this Repository
 


### PR DESCRIPTION
Fixes #18 

I added my email as a point of contact for violations. I can change this if people prefer. I also added a short blurb to the README as recommended by [Contributor Covenant](http://contributor-covenant.org/). While updating the README, I noticed we had a todo to add the completed documents, so I did that at the same time.

I generated the CC using their `covgen` tool, so it was trivial to add. Based on that, we could easily add the same full CC to all projects. I am fine with just a `CODE_OF_CONDUCT.md` with just a link though. If we approve this CC, I think we should decide that at the same time.

I would also like to add the **Code of Conduct** blurb to each projects `README.md` and maybe a short blurb with a link to this repository?

**Do not merge, I will merge once we have consensus/vote**